### PR TITLE
fix: introduce workaround for blank location name bug

### DIFF
--- a/locations/locations_from_app.json
+++ b/locations/locations_from_app.json
@@ -1,9 +1,12 @@
 [
     {
+        "name": ""
+    },
+    {
         "name": "",
         "sections": [
             {
-                "name": "Elixir [Riku]",
+                "name": "Elixir 2 [Riku]",
                 "access_rules": ["world_the_world_that_never_was_riku"]
             }
         ],


### PR DESCRIPTION
It turns out the first location in the array will not render a tooltip if it has a blank name (even if it has a section with a name). Add a blank location to work around this.